### PR TITLE
Refactor didiator typehints and interfaces

### DIFF
--- a/didiator/dispatchers/command.py
+++ b/didiator/dispatchers/command.py
@@ -17,5 +17,7 @@ class CommandDispatcherImpl(DispatcherImpl, CommandDispatcher):
     async def send(self, command: Command[CRes], *args: Any, **kwargs: Any) -> CRes:
         try:
             return await self._handle(command, *args, **kwargs)
-        except HandlerNotFound:
-            raise CommandHandlerNotFound(f"Command handler for {type(command).__name__} command is not registered", command)
+        except HandlerNotFound as err:
+            raise CommandHandlerNotFound(
+                f"Command handler for {type(command).__name__} command is not registered", command,
+            ) from err

--- a/didiator/dispatchers/query.py
+++ b/didiator/dispatchers/query.py
@@ -17,5 +17,7 @@ class QueryDispatcherImpl(DispatcherImpl, QueryDispatcher):
     async def query(self, query: Query[QRes], *args: Any, **kwargs: Any) -> QRes:
         try:
             return await self._handle(query, *args, **kwargs)
-        except HandlerNotFound:
-            raise QueryHandlerNotFound(f"Query handler for {type(query).__name__} query is not registered", query)
+        except HandlerNotFound as err:
+            raise QueryHandlerNotFound(
+                f"Query handler for {type(query).__name__} query is not registered", query,
+            ) from err

--- a/didiator/dispatchers/request.py
+++ b/didiator/dispatchers/request.py
@@ -9,14 +9,15 @@ from didiator.interface.dispatchers.request import Dispatcher
 
 RRes = TypeVar("RRes")
 R = TypeVar("R", bound=Request[Any])
+Middlewares = Sequence[MiddlewareType[Request[Any], Any]]
 
 DEFAULT_MIDDLEWARES: tuple[MiddlewareType[Request[Any], Any], ...] = (Middleware(),)
 
 
 class DispatcherImpl(Dispatcher, abc.ABC):
-    def __init__(self, middlewares: Sequence[MiddlewareType[Request[Any], Any]] = ()) -> None:
+    def __init__(self, middlewares: Middlewares = ()) -> None:
         self._handlers: dict[Type[Request[Any]], HandlerType[Request[Any], Any]] = {}
-        self._middlewares: Sequence[MiddlewareType[Request[Any], Any]] = middlewares
+        self._middlewares: Middlewares = middlewares
 
     def _register_handler(self, request: Type[R], handler: HandlerType[R, RRes]) -> None:
         self._handlers[request] = handler
@@ -32,11 +33,13 @@ class DispatcherImpl(Dispatcher, abc.ABC):
     async def _handle(self, request: Request[RRes], *args: Any, **kwargs: Any) -> RRes:
         try:
             handler = self._handlers[type(request)]
-        except KeyError:
-            raise HandlerNotFound(f"Request handler for {type(request).__name__} request is not registered", request)
+        except KeyError as err:
+            raise HandlerNotFound(
+                f"Request handler for {type(request).__name__} request is not registered", request,
+            ) from err
 
         # Handler has to be wrapped with at least one middleware to initialize the handler if it is necessary
-        middlewares: Sequence[MiddlewareType[Any, Any]] = self._middlewares if self._middlewares else DEFAULT_MIDDLEWARES
+        middlewares: Middlewares = self._middlewares if self._middlewares else DEFAULT_MIDDLEWARES
         wrapped_handler: Callable[..., Awaitable[RRes]] = self._wrap_middleware(middlewares, handler)
         return await wrapped_handler(request, *args, **kwargs)
 

--- a/didiator/interface/mediator.py
+++ b/didiator/interface/mediator.py
@@ -9,11 +9,11 @@ from didiator.interface.handlers.event import EventHandlerType
 from didiator.interface.handlers.query import QueryHandlerType
 
 Self = TypeVar("Self", bound="BaseMediator")
+E = TypeVar("E", bound=Event)
 C = TypeVar("C", bound=Command[Any])
 CRes = TypeVar("CRes")
 Q = TypeVar("Q", bound=Query[Any])
 QRes = TypeVar("QRes")
-E = TypeVar("E", bound=Event)
 
 
 class BaseMediator(Protocol):

--- a/didiator/interface/observers/event.py
+++ b/didiator/interface/observers/event.py
@@ -3,6 +3,7 @@ from typing import Any, Generic, Protocol, Type, TypeVar
 
 from didiator.interface.entities.event import Event
 from didiator.interface.handlers.event import EventHandlerType
+from didiator.middlewares.base import MiddlewareType
 
 E = TypeVar("E", bound=Event)
 
@@ -27,6 +28,10 @@ class Listener(Generic[E]):
 class EventObserver(Protocol):
     @property
     def listeners(self) -> tuple[Listener[Any], ...]:
+        raise NotImplementedError
+
+    @property
+    def middlewares(self) -> tuple[MiddlewareType[Event, Any], ...]:
         raise NotImplementedError
 
     def register_listener(self, listener: Listener[Any]) -> None:

--- a/didiator/observers/event.py
+++ b/didiator/observers/event.py
@@ -8,12 +8,13 @@ from didiator.interface.handlers.event import EventHandlerType
 from didiator.middlewares.base import MiddlewareType, wrap_middleware
 
 E = TypeVar("E", bound=Event)
+Middlewares = Sequence[MiddlewareType[Event, Any]]
 
 
 class EventObserverImpl(EventObserver):
-    def __init__(self, middlewares: Sequence[MiddlewareType[Event, Any]] = ()) -> None:
+    def __init__(self, middlewares: Middlewares = ()) -> None:
         self._listeners: list[Listener[Event]] = []
-        self._middlewares: Sequence[MiddlewareType[Event, Any]] = middlewares
+        self._middlewares: Middlewares = middlewares
 
     @property
     def listeners(self) -> tuple[Listener[Event], ...]:
@@ -31,7 +32,7 @@ class EventObserverImpl(EventObserver):
 
     async def _handle(self, events: Sequence[Event], *args: Any, **kwargs: Any) -> None:
         # Handler has to be wrapped with at least one middleware to initialize the handler if it is necessary
-        middlewares = self._middlewares if self._middlewares else DEFAULT_MIDDLEWARES
+        middlewares: Middlewares = self._middlewares if self._middlewares else DEFAULT_MIDDLEWARES
 
         for event in events:
             for listener in self._listeners:
@@ -41,7 +42,7 @@ class EventObserverImpl(EventObserver):
 
     @staticmethod
     def _wrap_middleware(
-        middlewares: Sequence[MiddlewareType[E, Any]],
+        middlewares: Middlewares,
         handler: EventHandlerType[E],
     ) -> Callable[..., Awaitable[Any]]:
         return wrap_middleware(middlewares, handler)

--- a/didiator/utils/di_builder.py
+++ b/didiator/utils/di_builder.py
@@ -30,7 +30,7 @@ class DiBuilder:
 
     async def execute(
         self, call: DependencyProviderType[T], scope: Scope,
-        *, state: ContainerState | None = None, values: Mapping[DependencyProvider, Any] | None = None,
+        *, state: ContainerState, values: Mapping[DependencyProvider, Any] | None = None,
     ) -> T:
         solved_dependency = self.get_solved(call, scope)
         return await self._di_container.execute_async(


### PR DESCRIPTION
- Add middlewares property to EventObserver
- Add chained error raising to dispatchers
- Refactor typehints in EventObserver
- Fix DiBuilder: remove default None value for the `execute` method
