### PR TITLE
Fix copy `_bind_hooks`

### DIFF
--- a/didiator/__init__.py
+++ b/didiator/__init__.py
@@ -6,7 +6,7 @@ from .interface.handlers import CommandHandler, QueryHandler
 from .interface.mediator import Mediator, CommandMediator, QueryMediator, EventMediator
 from .mediator import MediatorImpl
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = (
     "__version__",

--- a/didiator/utils/di_builder.py
+++ b/didiator/utils/di_builder.py
@@ -53,7 +53,7 @@ class DiBuilderImpl(DiBuilder):
 
     def copy(self) -> "DiBuilderImpl":
         di_container = Container()
-        di_container._bind_hooks = self._di_container._bind_hooks  # noqa
+        di_container._bind_hooks = self._di_container._bind_hooks.copy()  # noqa
         return DiBuilderImpl(
             di_container, self._di_executor, self.di_scopes, solved_dependencies=self._solved_dependencies,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "didiator"
-version = "0.3.0"
+version = "0.3.1"
 description = "A library that implements the Mediator pattern and uses DI library"
 authors = [
     "SamWarden <SamWardenSad@gmail.com>",


### PR DESCRIPTION
- Fix copy `_bind_hooks`
- Bump didiator version to v0.3.1
